### PR TITLE
Strongly type Webhook configuration

### DIFF
--- a/overlays/webhookConfiguration.ts
+++ b/overlays/webhookConfiguration.ts
@@ -1,0 +1,17 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+// TODO: https://github.com/pulumi/pulumi-terraform/issues/111
+// Rename `content_type` and `insecure_ssl` to `contentType` and `insecureSsl`
+// to match the naming scheme we use everywhere else once we're able to
+// indicate a map's names should be transformed. Until then, we need to keep
+// the names as `content_type` and `insecure_ssl` as those are the names that
+// GitHub expects.
+
+export interface WebhookConfiguration {
+    readonly url: string;
+    readonly content_type?: ContentType;
+    readonly secret?: string;
+    readonly insecure_ssl?: string;
+}
+
+export type ContentType = "form" | "json";

--- a/resources.go
+++ b/resources.go
@@ -66,7 +66,14 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
-			"github_organization_webhook": {Tok: githubResource(orgsMod, "Webhook")},
+			"github_organization_webhook": {
+				Tok: githubResource(orgsMod, "Webhook"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"configuration": {
+						Type: githubType(githubMod, "WebhookConfiguration"),
+					},
+				},
+			},
 			"github_repository_collaborator": {
 				Tok: githubResource(reposMod, "Collaborator"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -76,8 +83,15 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			"github_repository_deploy_key": {Tok: githubResource(reposMod, "DeployKey")},
-			"github_repository_webhook":    {Tok: githubResource(reposMod, "Webhook")},
-			"github_repository":            {Tok: githubResource(reposMod, "Repository")},
+			"github_repository_webhook": {
+				Tok: githubResource(reposMod, "Webhook"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"configuration": {
+						Type: githubType(githubMod, "WebhookConfiguration"),
+					},
+				},
+			},
+			"github_repository": {Tok: githubResource(reposMod, "Repository")},
 			"github_team_membership": {
 				Tok: githubResource(teamsMod, "Membership"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -110,6 +124,7 @@ func Provider() tfbridge.ProviderInfo {
 		Overlay: &tfbridge.OverlayInfo{
 			Files: []string{
 				"permission.ts",
+				"webhookConfiguration.ts",
 			},
 			Modules: map[string]*tfbridge.OverlayInfo{
 				"orgs": {


### PR DESCRIPTION
Once this is merged, I'm going to add a tag with an initial version, which will hopefully address the CI badge issue.

@joeduffy, mind taking a quick look? (Sorry to keep tagging you for review.)

---

From the [docs](https://developer.github.com/v3/repos/hooks/#create-a-hook):

Name | Type | Description
-- | -- | --
url | string | Required The URL to which the payloads will be delivered.
content_type | string | The media type used to serialize the payloads. Supported values include json and form. The default is form.
secret | string | If provided, the secret will be used as the key to generate the HMAC hex digest value in the X-Hub-Signature header.
insecure_ssl | string | Determines whether the SSL certificate of the host for urlwill be verified when delivering payloads. Supported values include 0 (verification is performed) and 1 (verification is not performed). The default is 0. We strongly recommend not setting this to 1 as you are subject to man-in-the-middle and other attacks.
