### PR TITLE
[WIP] Use camel case for WebhookConfiguration properties

### DIFF
--- a/overlays/webhookConfiguration.ts
+++ b/overlays/webhookConfiguration.ts
@@ -2,18 +2,11 @@
 
 import * as pulumi from "@pulumi/pulumi";
 
-// TODO: https://github.com/pulumi/pulumi-terraform/issues/111
-// Rename `content_type` and `insecure_ssl` to `contentType` and `insecureSsl`
-// to match the naming scheme we use everywhere else once we're able to
-// indicate a map's names should be transformed. Until then, we need to keep
-// the names as `content_type` and `insecure_ssl` as those are the names that
-// GitHub expects.
-
 export interface WebhookConfiguration {
     readonly url: pulumi.Input<string>;
-    readonly content_type?: pulumi.Input<ContentType>;
+    readonly contentType?: pulumi.Input<ContentType>;
     readonly secret?: pulumi.Input<string>;
-    readonly insecure_ssl?: pulumi.Input<string>;
+    readonly insecureSsl?: pulumi.Input<string>;
 }
 
 export type ContentType = "form" | "json";

--- a/resources.go
+++ b/resources.go
@@ -74,7 +74,8 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: githubResource(orgsMod, "Webhook"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"configuration": {
-						Type: githubType(githubMod, "WebhookConfiguration"),
+						Type:              githubType(githubMod, "WebhookConfiguration"),
+						MangleTypeMapKeys: boolPointer(true),
 					},
 				},
 			},
@@ -91,7 +92,8 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: githubResource(reposMod, "Webhook"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"configuration": {
-						Type: githubType(githubMod, "WebhookConfiguration"),
+						Type:              githubType(githubMod, "WebhookConfiguration"),
+						MangleTypeMapKeys: boolPointer(true),
 					},
 				},
 			},
@@ -153,4 +155,8 @@ func Provider() tfbridge.ProviderInfo {
 	}
 
 	return prov
+}
+
+func boolPointer(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
Depends on https://github.com/pulumi/pulumi-terraform/pull/133. I'll update the revision in `Gopkg.toml` once that lands.

---

Turn on TypeMap key mangling for the webhook `configuration` fields to enable Pulumi-style camel casing of the properties on `WebhookConfiguration`.

Fixes #8