### PR TITLE
Avoid baking config from environment into checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Avoid storing config from the environment into the state
 
 ---
 

--- a/provider/cmd/pulumi-resource-github/schema.json
+++ b/provider/cmd/pulumi-resource-github/schema.json
@@ -30,12 +30,7 @@
             },
             "organization": {
                 "type": "string",
-                "description": "The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.\n",
-                "defaultInfo": {
-                    "environment": [
-                        "GITHUB_ORGANIZATION"
-                    ]
-                }
+                "description": "The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.\n"
             },
             "owner": {
                 "type": "string",
@@ -43,12 +38,7 @@
             },
             "token": {
                 "type": "string",
-                "description": "The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.\n",
-                "defaultInfo": {
-                    "environment": [
-                        "GITHUB_TOKEN"
-                    ]
-                }
+                "description": "The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.\n"
             }
         }
     },
@@ -824,12 +814,7 @@
             },
             "organization": {
                 "type": "string",
-                "description": "The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.\n",
-                "defaultInfo": {
-                    "environment": [
-                        "GITHUB_ORGANIZATION"
-                    ]
-                }
+                "description": "The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.\n"
             },
             "owner": {
                 "type": "string",
@@ -837,12 +822,7 @@
             },
             "token": {
                 "type": "string",
-                "description": "The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.\n",
-                "defaultInfo": {
-                    "environment": [
-                        "GITHUB_TOKEN"
-                    ]
-                }
+                "description": "The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.\n"
             }
         }
     },

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -86,16 +86,6 @@ func Provider() tfbridge.ProviderInfo {
 		Homepage:    "https://pulumi.io",
 		Repository:  "https://github.com/pulumi/pulumi-github",
 		Config: map[string]*tfbridge.SchemaInfo{
-			"token": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"GITHUB_TOKEN"},
-				},
-			},
-			"organization": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"GITHUB_ORGANIZATION"},
-				},
-			},
 			"base_url": {
 				Default: &tfbridge.DefaultInfo{
 					EnvVars: []string{"GITHUB_BASE_URL"},

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -21,7 +21,7 @@ namespace Pulumi.Github
         /// <summary>
         /// The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.
         /// </summary>
-        public static string? Organization { get; set; } = __config.Get("organization") ?? Utilities.GetEnv("GITHUB_ORGANIZATION");
+        public static string? Organization { get; set; } = __config.Get("organization");
 
         /// <summary>
         /// The GitHub owner name to manage. Use this field instead of `organization` when managing individual accounts.
@@ -31,7 +31,7 @@ namespace Pulumi.Github
         /// <summary>
         /// The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.
         /// </summary>
-        public static string? Token { get; set; } = __config.Get("token") ?? Utilities.GetEnv("GITHUB_TOKEN");
+        public static string? Token { get; set; } = __config.Get("token");
 
     }
 }

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -78,8 +78,6 @@ namespace Pulumi.Github
         public ProviderArgs()
         {
             BaseUrl = Utilities.GetEnv("GITHUB_BASE_URL") ?? "https://api.github.com/";
-            Organization = Utilities.GetEnv("GITHUB_ORGANIZATION");
-            Token = Utilities.GetEnv("GITHUB_TOKEN");
         }
     }
 }

--- a/sdk/go/github/config/config.go
+++ b/sdk/go/github/config/config.go
@@ -24,11 +24,7 @@ func GetInsecure(ctx *pulumi.Context) bool {
 
 // The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.
 func GetOrganization(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "github:organization")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "GITHUB_ORGANIZATION").(string)
+	return config.Get(ctx, "github:organization")
 }
 
 // The GitHub owner name to manage. Use this field instead of `organization` when managing individual accounts.
@@ -38,9 +34,5 @@ func GetOwner(ctx *pulumi.Context) string {
 
 // The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.
 func GetToken(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "github:token")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "GITHUB_TOKEN").(string)
+	return config.Get(ctx, "github:token")
 }

--- a/sdk/go/github/provider.go
+++ b/sdk/go/github/provider.go
@@ -28,12 +28,6 @@ func NewProvider(ctx *pulumi.Context,
 	if args.BaseUrl == nil {
 		args.BaseUrl = pulumi.StringPtr(getEnvOrDefault("https://api.github.com/", nil, "GITHUB_BASE_URL").(string))
 	}
-	if args.Organization == nil {
-		args.Organization = pulumi.StringPtr(getEnvOrDefault("", nil, "GITHUB_ORGANIZATION").(string))
-	}
-	if args.Token == nil {
-		args.Token = pulumi.StringPtr(getEnvOrDefault("", nil, "GITHUB_TOKEN").(string))
-	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:github", name, args, &resource, opts...)
 	if err != nil {

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -17,7 +17,7 @@ export let insecure: boolean | undefined = __config.getObject<boolean>("insecure
 /**
  * The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.
  */
-export let organization: string | undefined = __config.get("organization") || utilities.getEnv("GITHUB_ORGANIZATION");
+export let organization: string | undefined = __config.get("organization");
 /**
  * The GitHub owner name to manage. Use this field instead of `organization` when managing individual accounts.
  */
@@ -25,4 +25,4 @@ export let owner: string | undefined = __config.get("owner");
 /**
  * The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.
  */
-export let token: string | undefined = __config.get("token") || utilities.getEnv("GITHUB_TOKEN");
+export let token: string | undefined = __config.get("token");

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -38,9 +38,9 @@ export class Provider extends pulumi.ProviderResource {
         {
             inputs["baseUrl"] = (args ? args.baseUrl : undefined) || (utilities.getEnv("GITHUB_BASE_URL") || "https://api.github.com/");
             inputs["insecure"] = pulumi.output(args ? args.insecure : undefined).apply(JSON.stringify);
-            inputs["organization"] = (args ? args.organization : undefined) || utilities.getEnv("GITHUB_ORGANIZATION");
+            inputs["organization"] = args ? args.organization : undefined;
             inputs["owner"] = args ? args.owner : undefined;
-            inputs["token"] = (args ? args.token : undefined) || utilities.getEnv("GITHUB_TOKEN");
+            inputs["token"] = args ? args.token : undefined;
         }
         if (!opts) {
             opts = {}

--- a/sdk/python/pulumi_github/config/vars.py
+++ b/sdk/python/pulumi_github/config/vars.py
@@ -28,7 +28,7 @@ insecure = __config__.get('insecure')
 Enable `insecure` mode for testing purposes
 """
 
-organization = __config__.get('organization') or _utilities.get_env('GITHUB_ORGANIZATION')
+organization = __config__.get('organization')
 """
 The GitHub organization name to manage. Use this field instead of `owner` when managing organization accounts.
 """
@@ -38,7 +38,7 @@ owner = __config__.get('owner')
 The GitHub owner name to manage. Use this field instead of `organization` when managing individual accounts.
 """
 
-token = __config__.get('token') or _utilities.get_env('GITHUB_TOKEN')
+token = __config__.get('token')
 """
 The OAuth token used to connect to GitHub. `anonymous` mode is enabled if `token` is not configured.
 """

--- a/sdk/python/pulumi_github/provider.py
+++ b/sdk/python/pulumi_github/provider.py
@@ -58,12 +58,8 @@ class Provider(pulumi.ProviderResource):
                 base_url = (_utilities.get_env('GITHUB_BASE_URL') or 'https://api.github.com/')
             __props__['base_url'] = base_url
             __props__['insecure'] = pulumi.Output.from_input(insecure).apply(pulumi.runtime.to_json) if insecure is not None else None
-            if organization is None:
-                organization = _utilities.get_env('GITHUB_ORGANIZATION')
             __props__['organization'] = organization
             __props__['owner'] = owner
-            if token is None:
-                token = _utilities.get_env('GITHUB_TOKEN')
             __props__['token'] = token
         super(Provider, __self__).__init__(
             'github',


### PR DESCRIPTION
Like in pulumi/pulumi-aws#894, we will avoid baking any provider configuration
from environment variables into the checkpoint file for any potentially transient
configuration (like credentials) that is not part of the "identity" of the provider.

Fixes #95.