### PR TITLE
Remove Go111Module env

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,7 +2,6 @@ env:
   GH_ORGANIZATION: ${{ secrets.GH_ORGANIZATION }}
   GH_TESTING_TOKEN: ${{ secrets.GH_TESTING_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GO111MODULE: "on"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,7 +2,6 @@ env:
   GH_ORGANIZATION: ${{ secrets.GH_ORGANIZATION }}
   GH_TESTING_TOKEN: ${{ secrets.GH_TESTING_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GO111MODULE: "on"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,6 @@ env:
   GH_ORGANIZATION: ${{ secrets.GH_ORGANIZATION }}
   GH_TESTING_TOKEN: ${{ secrets.GH_TESTING_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GO111MODULE: "on"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ env:
   GH_ORGANIZATION: ${{ secrets.GH_ORGANIZATION }}
   GH_TESTING_TOKEN: ${{ secrets.GH_TESTING_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GO111MODULE: "on"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}

--- a/.github/workflows/update-bridge.yml
+++ b/.github/workflows/update-bridge.yml
@@ -2,7 +2,6 @@ env:
   GH_ORGANIZATION: ${{ secrets.GH_ORGANIZATION }}
   GH_TESTING_TOKEN: ${{ secrets.GH_TESTING_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GO111MODULE: "on"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -16,7 +16,6 @@ builds:
   dir: provider
   env:
   - CGO_ENABLED=0
-  - GO111MODULE=on
   goarch:
   - amd64
   - arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,6 @@ builds:
   dir: provider
   env:
   - CGO_ENABLED=0
-  - GO111MODULE=on
   goarch:
   - amd64
   - arm64


### PR DESCRIPTION
## What

As title.

## Why

Because from Go 1.16, the `GO111MODULE` are `true` by default.