### PR TITLE
Fix npm install failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,7 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.7
+      uses: pulumi/pulumi-package-publisher@295ac32fdcff28015f2710ce640bf67a8388e89a
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -361,7 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.7
+      uses: pulumi/pulumi-package-publisher@295ac32fdcff28015f2710ce640bf67a8388e89a
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -311,7 +311,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.7
+      uses: pulumi/pulumi-package-publisher@295ac32fdcff28015f2710ce640bf67a8388e89a
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.7
+      uses: pulumi/pulumi-package-publisher@295ac32fdcff28015f2710ce640bf67a8388e89a
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
Running `npm install` fails due to a missing script in the packaged tarball. This updates the pulumi-package-publisher to include this script, prior to wider rollout.

After this is merged, the main branch workflow will publish an [alpha release to NPM](https://www.npmjs.com/package/@pulumi/github?activeTab=versions), and we can verify `npm install` behavior against that.

If this succeeds, we'll update pulumi-package-publisher and then roll out to all providers.

See:
- pulumi/pulumi-package-publisher#11
- pulumi/pulumi-package-publisher#10
- pulumi/pulumi-azure#1301