### PR TITLE
Allow `token` to be discovered by env var

### DIFF
--- a/provider/cmd/pulumi-resource-github/schema.json
+++ b/provider/cmd/pulumi-resource-github/schema.json
@@ -102,7 +102,13 @@
             },
             "token": {
                 "type": "string",
-                "description": "The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.\n"
+                "description": "The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.\n",
+                "defaultInfo": {
+                    "environment": [
+                        "GITHUB_TOKEN"
+                    ]
+                },
+                "secret": true
             },
             "writeDelayMs": {
                 "type": "integer",
@@ -2865,7 +2871,8 @@
             },
             "token": {
                 "type": "string",
-                "description": "The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.\n"
+                "description": "The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.\n",
+                "secret": true
             },
             "writeDelayMs": {
                 "type": "integer",
@@ -2925,7 +2932,13 @@
             },
             "token": {
                 "type": "string",
-                "description": "The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.\n"
+                "description": "The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.\n",
+                "defaultInfo": {
+                    "environment": [
+                        "GITHUB_TOKEN"
+                    ]
+                },
+                "secret": true
             },
             "writeDelayMs": {
                 "type": "integer",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -91,6 +91,12 @@ func Provider() tfbridge.ProviderInfo {
 					Value:   "https://api.github.com/",
 				},
 			},
+			"token": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"GITHUB_TOKEN"},
+				},
+				Secret: tfbridge.True(),
+			},
 		},
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"github_actions_environment_secret": {DeleteBeforeReplace: true},

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -137,7 +137,7 @@ namespace Pulumi.Github
             set => _retryableErrors.Set(value);
         }
 
-        private static readonly __Value<string?> _token = new __Value<string?>(() => __config.Get("token"));
+        private static readonly __Value<string?> _token = new __Value<string?>(() => __config.Get("token") ?? Utilities.GetEnv("GITHUB_TOKEN"));
         /// <summary>
         /// The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.
         /// </summary>

--- a/sdk/go/github/config/config.go
+++ b/sdk/go/github/config/config.go
@@ -78,7 +78,15 @@ func GetRetryableErrors(ctx *pulumi.Context) string {
 
 // The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `appAuth` are not set.
 func GetToken(ctx *pulumi.Context) string {
-	return config.Get(ctx, "github:token")
+	v, err := config.Try(ctx, "github:token")
+	if err == nil {
+		return v
+	}
+	var value string
+	if d := internal.GetEnvOrDefault(nil, nil, "GITHUB_TOKEN"); d != nil {
+		value = d.(string)
+	}
+	return value
 }
 
 // Amount of time in milliseconds to sleep in between writes to GitHub API. Defaults to 1000ms or 1s if not set.

--- a/sdk/go/github/provider.go
+++ b/sdk/go/github/provider.go
@@ -42,6 +42,18 @@ func NewProvider(ctx *pulumi.Context,
 			args.BaseUrl = pulumi.StringPtr(d.(string))
 		}
 	}
+	if args.Token == nil {
+		if d := internal.GetEnvOrDefault(nil, nil, "GITHUB_TOKEN"); d != nil {
+			args.Token = pulumi.StringPtr(d.(string))
+		}
+	}
+	if args.Token != nil {
+		args.Token = pulumi.ToSecret(args.Token).(pulumi.StringPtrInput)
+	}
+	secrets := pulumi.AdditionalSecretOutputs([]string{
+		"token",
+	})
+	opts = append(opts, secrets)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:github", name, args, &resource, opts...)

--- a/sdk/java/src/main/java/com/pulumi/github/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/github/Config.java
@@ -95,7 +95,7 @@ public final class Config {
  * 
  */
     public Optional<String> token() {
-        return Codegen.stringProp("token").config(config).get();
+        return Codegen.stringProp("token").config(config).env("GITHUB_TOKEN").get();
     }
 /**
  * Amount of time in milliseconds to sleep in between writes to GitHub API. Defaults to 1000ms or 1s if not set.

--- a/sdk/java/src/main/java/com/pulumi/github/Provider.java
+++ b/sdk/java/src/main/java/com/pulumi/github/Provider.java
@@ -10,6 +10,7 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.github.ProviderArgs;
 import com.pulumi.github.Utilities;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -111,6 +112,9 @@ public class Provider extends com.pulumi.resources.ProviderResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .additionalSecretOutputs(List.of(
+                "token"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/com/pulumi/github/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/github/ProviderArgs.java
@@ -536,6 +536,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
 
         public ProviderArgs build() {
             $.baseUrl = Codegen.stringProp("baseUrl").output().arg($.baseUrl).env("GITHUB_BASE_URL").def("https://api.github.com/").getNullable();
+            $.token = Codegen.stringProp("token").secret().arg($.token).env("GITHUB_TOKEN").getNullable();
             return $;
         }
     }

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -130,7 +130,7 @@ Object.defineProperty(exports, "retryableErrors", {
 export declare const token: string | undefined;
 Object.defineProperty(exports, "token", {
     get() {
-        return __config.get("token");
+        return __config.get("token") ?? utilities.getEnv("GITHUB_TOKEN");
     },
     enumerable: true,
 });

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -67,10 +67,12 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["readDelayMs"] = pulumi.output(args ? args.readDelayMs : undefined).apply(JSON.stringify);
             resourceInputs["retryDelayMs"] = pulumi.output(args ? args.retryDelayMs : undefined).apply(JSON.stringify);
             resourceInputs["retryableErrors"] = pulumi.output(args ? args.retryableErrors : undefined).apply(JSON.stringify);
-            resourceInputs["token"] = args ? args.token : undefined;
+            resourceInputs["token"] = (args?.token ? pulumi.secret(args.token) : undefined) ?? utilities.getEnv("GITHUB_TOKEN");
             resourceInputs["writeDelayMs"] = pulumi.output(args ? args.writeDelayMs : undefined).apply(JSON.stringify);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const secretOpts = { additionalSecretOutputs: ["token"] };
+        opts = pulumi.mergeOptions(opts, secretOpts);
         super(Provider.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_github/config/vars.py
+++ b/sdk/python/pulumi_github/config/vars.py
@@ -96,7 +96,7 @@ class _ExportableConfig(types.ModuleType):
         """
         The OAuth token used to connect to GitHub. Anonymous mode is enabled if both `token` and `app_auth` are not set.
         """
-        return __config__.get('token')
+        return __config__.get('token') or _utilities.get_env('GITHUB_TOKEN')
 
     @property
     def write_delay_ms(self) -> Optional[int]:

--- a/sdk/python/pulumi_github/provider.py
+++ b/sdk/python/pulumi_github/provider.py
@@ -72,6 +72,8 @@ class ProviderArgs:
             pulumi.set(__self__, "retry_delay_ms", retry_delay_ms)
         if retryable_errors is not None:
             pulumi.set(__self__, "retryable_errors", retryable_errors)
+        if token is None:
+            token = _utilities.get_env('GITHUB_TOKEN')
         if token is not None:
             pulumi.set(__self__, "token", token)
         if write_delay_ms is not None:
@@ -334,8 +336,12 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["read_delay_ms"] = pulumi.Output.from_input(read_delay_ms).apply(pulumi.runtime.to_json) if read_delay_ms is not None else None
             __props__.__dict__["retry_delay_ms"] = pulumi.Output.from_input(retry_delay_ms).apply(pulumi.runtime.to_json) if retry_delay_ms is not None else None
             __props__.__dict__["retryable_errors"] = pulumi.Output.from_input(retryable_errors).apply(pulumi.runtime.to_json) if retryable_errors is not None else None
-            __props__.__dict__["token"] = token
+            if token is None:
+                token = _utilities.get_env('GITHUB_TOKEN')
+            __props__.__dict__["token"] = None if token is None else pulumi.Output.secret(token)
             __props__.__dict__["write_delay_ms"] = pulumi.Output.from_input(write_delay_ms).apply(pulumi.runtime.to_json) if write_delay_ms is not None else None
+        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["token"])
+        opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(Provider, __self__).__init__(
             'github',
             resource_name,


### PR DESCRIPTION
Allow `token` to be set via the `GITHUB_TOKEN` env var.

This provides a partial workaround for https://github.com/pulumi/pulumi-github/issues/203.