### PR TITLE
Make tests work for both PRC and non-PRC

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -122,49 +122,13 @@ const repro586 = `[
             }
         },
         "response": {
-            "replaces": [
+            "stables": [
                 "repositoryId"
             ],
             "changes": "DIFF_SOME",
             "diffs": "*",
             "detailedDiff": {
-                "allowsDeletions": {
-                    "kind": "UPDATE"
-                },
-                "allowsForcePushes": {
-                    "kind": "UPDATE"
-                },
-                "enforceAdmins": {
-                    "kind": "UPDATE"
-                },
-                "lockBranch": {
-                    "kind": "UPDATE"
-                },
-                "pattern": {
-                    "kind": "UPDATE"
-                },
-                "repositoryId": {
-                    "kind": "UPDATE_REPLACE"
-                },
-                "requireConversationResolution": {
-                    "kind": "UPDATE"
-                },
-                "requireSignedCommits": {
-                    "kind": "UPDATE"
-                },
-                "requiredLinearHistory": {
-                    "kind": "UPDATE"
-                },
-                "requiredPullRequestReviews": {
-                    "kind": "UPDATE"
-                },
-                "requiredPullRequestReviews[0].dismissStaleReviews": {
-                    "kind": "UPDATE"
-                },
-                "requiredPullRequestReviews[0].requireLastPushApproval": {
-                    "kind": "UPDATE"
-                },
-                "requiredPullRequestReviews[0].requiredApprovingReviewCount": {
+                "restrictPushes": {
                     "kind": "UPDATE"
                 },
                 "restrictPushes[0].blocksCreations": {},

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -12,7 +12,179 @@ import (
 	"github.com/pulumi/pulumi-github/provider/v6/pkg/version"
 )
 
-const repro586 = `[
+const repro586nonPRC = `[
+{
+        "method": "/pulumirpc.ResourceProvider/Diff",
+        "request": {
+            "id": "BPR_kwDOLcEl984C1wZz",
+            "urn": "urn:pulumi:dev::ts::github:index/branchProtection:BranchProtection::debug-pulumi-github-protection",
+            "olds": {
+                "__meta": "{\"schema_version\":\"1\"}",
+                "allowsDeletions": false,
+                "allowsForcePushes": false,
+                "blocksCreations": false,
+                "enforceAdmins": true,
+                "forcePushBypassers": [],
+                "id": "BPR_kwDOLcEl984C1wZz",
+                "lockBranch": false,
+                "pattern": "main",
+                "pushRestrictions": [
+                    "/iwahbe"
+                ],
+                "repositoryId": "debug-pulumi-github",
+                "requireConversationResolution": false,
+                "requireSignedCommits": false,
+                "requiredLinearHistory": false,
+                "requiredPullRequestReviews": [
+                    {
+                        "dismissStaleReviews": true,
+                        "dismissalRestrictions": [],
+                        "pullRequestBypassers": [],
+                        "requireCodeOwnerReviews": false,
+                        "requireLastPushApproval": false,
+                        "requiredApprovingReviewCount": 1,
+                        "restrictDismissals": false
+                    }
+                ],
+                "requiredStatusChecks": []
+            },
+            "news": {
+                "__defaults": [
+                    "allowsForcePushes",
+                    "lockBranch",
+                    "requireConversationResolution",
+                    "requireSignedCommits",
+                    "requiredLinearHistory"
+                ],
+                "allowsDeletions": false,
+                "allowsForcePushes": false,
+                "enforceAdmins": true,
+                "lockBranch": false,
+                "pattern": "main",
+                "repositoryId": "debug-pulumi-github",
+                "requireConversationResolution": false,
+                "requireSignedCommits": false,
+                "requiredLinearHistory": false,
+                "requiredPullRequestReviews": [
+                    {
+                        "__defaults": [
+                            "requireLastPushApproval"
+                        ],
+                        "dismissStaleReviews": true,
+                        "requireLastPushApproval": false,
+                        "requiredApprovingReviewCount": 1
+                    }
+                ],
+                "restrictPushes": [
+                    {
+                        "__defaults": [
+                            "blocksCreations"
+                        ],
+                        "blocksCreations": true,
+                        "pushAllowances": [
+                            "/iwahbe"
+                        ]
+                    }
+                ]
+            },
+            "oldInputs": {
+                "__defaults": [
+                    "allowsForcePushes",
+                    "blocksCreations",
+                    "lockBranch",
+                    "requireConversationResolution",
+                    "requireSignedCommits",
+                    "requiredLinearHistory"
+                ],
+                "allowsDeletions": false,
+                "allowsForcePushes": false,
+                "blocksCreations": false,
+                "enforceAdmins": true,
+                "lockBranch": false,
+                "pattern": "main",
+                "pushRestrictions": [
+                    "/iwahbe"
+                ],
+                "repositoryId": "debug-pulumi-github",
+                "requireConversationResolution": false,
+                "requireSignedCommits": false,
+                "requiredLinearHistory": false,
+                "requiredPullRequestReviews": [
+                    {
+                        "__defaults": [
+                            "requireLastPushApproval"
+                        ],
+                        "dismissStaleReviews": true,
+                        "requireLastPushApproval": false,
+                        "requiredApprovingReviewCount": 1
+                    }
+                ]
+            }
+        },
+        "response": {
+            "replaces": [
+                "repositoryId"
+            ],
+            "changes": "DIFF_SOME",
+            "diffs": "*",
+            "detailedDiff": {
+                "allowsDeletions": {
+                    "kind": "UPDATE"
+                },
+                "allowsForcePushes": {
+                    "kind": "UPDATE"
+                },
+                "enforceAdmins": {
+                    "kind": "UPDATE"
+                },
+                "lockBranch": {
+                    "kind": "UPDATE"
+                },
+                "pattern": {
+                    "kind": "UPDATE"
+                },
+                "repositoryId": {
+                    "kind": "UPDATE_REPLACE"
+                },
+                "requireConversationResolution": {
+                    "kind": "UPDATE"
+                },
+                "requireSignedCommits": {
+                    "kind": "UPDATE"
+                },
+                "requiredLinearHistory": {
+                    "kind": "UPDATE"
+                },
+                "requiredPullRequestReviews": {
+                    "kind": "UPDATE"
+                },
+                "requiredPullRequestReviews[0].dismissStaleReviews": {
+                    "kind": "UPDATE"
+                },
+                "requiredPullRequestReviews[0].requireLastPushApproval": {
+                    "kind": "UPDATE"
+                },
+                "requiredPullRequestReviews[0].requiredApprovingReviewCount": {
+                    "kind": "UPDATE"
+                },
+                "restrictPushes[0].blocksCreations": {},
+                "restrictPushes[0].pushAllowances": {
+                    "kind": "UPDATE"
+                },
+                "restrictPushes[0].pushAllowances[0]": {}
+            },
+            "hasDetailedDiff": true
+        },
+        "metadata": {
+            "kind": "resource",
+            "mode": "client",
+            "name": "github"
+        }
+    }
+]
+`
+
+const repro586PRC = `[
 {
         "method": "/pulumirpc.ResourceProvider/Diff",
         "request": {
@@ -149,8 +321,14 @@ const repro586 = `[
 `
 
 func TestRepros(t *testing.T) {
+	// TODO: Remove non-prc test after enabling PRC by default.
 	t.Run("586", func(t *testing.T) {
-		replay.ReplaySequence(t, server(t), repro586)
+		defer func() {
+			if r := recover(); r != nil {
+				replay.ReplaySequence(t, server(t), repro586PRC)
+			}
+		}()
+		replay.ReplaySequence(t, server(t), repro586nonPRC)
 	})
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -321,7 +321,7 @@ const repro586PRC = `[
 `
 
 func TestRepros(t *testing.T) {
-	// TODO: Remove non-prc test after enabling PRC by default.
+	// TODO[pulumi/pulumi-github#707]: Remove non-prc test after enabling PRC by default.
 	t.Run("586", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {


### PR DESCRIPTION
related to https://github.com/pulumi/pulumi-terraform-bridge/issues/1785

The GRPC test asserts on secondary behaviour which change under PRC. This adapts the test to pass under both PRC and non-PRC.

This removes the need to sync bridge changes to changes in the provider repo, allowing an easier time running downstream tests. Will clean up after enabling PRC by default here.