### PR TITLE
Replace user and organization secrets on repository selection changes

### DIFF
--- a/provider/cmd/pulumi-resource-github/schema.json
+++ b/provider/cmd/pulumi-resource-github/schema.json
@@ -3378,7 +3378,8 @@
                     "items": {
                         "type": "integer"
                     },
-                    "description": "An array of repository ids that can access the organization secret.\n"
+                    "description": "An array of repository ids that can access the organization secret.\n",
+                    "willReplaceOnChanges": true
                 },
                 "visibility": {
                     "type": "string",
@@ -3419,7 +3420,8 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "An array of repository ids that can access the organization secret.\n"
+                        "description": "An array of repository ids that can access the organization secret.\n",
+                        "willReplaceOnChanges": true
                     },
                     "updatedAt": {
                         "type": "string",
@@ -4812,7 +4814,8 @@
                     "items": {
                         "type": "integer"
                     },
-                    "description": "An array of repository ids that can access the organization secret.\n"
+                    "description": "An array of repository ids that can access the organization secret.\n",
+                    "willReplaceOnChanges": true
                 },
                 "visibility": {
                     "type": "string",
@@ -4853,7 +4856,8 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "An array of repository ids that can access the organization secret.\n"
+                        "description": "An array of repository ids that can access the organization secret.\n",
+                        "willReplaceOnChanges": true
                     },
                     "updatedAt": {
                         "type": "string",
@@ -5086,7 +5090,8 @@
                     "items": {
                         "type": "integer"
                     },
-                    "description": "An array of repository ids that can access the user secret.\n"
+                    "description": "An array of repository ids that can access the user secret.\n",
+                    "willReplaceOnChanges": true
                 }
             },
             "requiredInputs": [
@@ -5121,7 +5126,8 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "An array of repository ids that can access the user secret.\n"
+                        "description": "An array of repository ids that can access the user secret.\n",
+                        "willReplaceOnChanges": true
                     },
                     "updatedAt": {
                         "type": "string",
@@ -5197,7 +5203,8 @@
                     "items": {
                         "type": "integer"
                     },
-                    "description": "An array of repository ids that can access the organization secret.\n"
+                    "description": "An array of repository ids that can access the organization secret.\n",
+                    "willReplaceOnChanges": true
                 },
                 "visibility": {
                     "type": "string",
@@ -5238,7 +5245,8 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "An array of repository ids that can access the organization secret.\n"
+                        "description": "An array of repository ids that can access the organization secret.\n",
+                        "willReplaceOnChanges": true
                     },
                     "updatedAt": {
                         "type": "string",


### PR DESCRIPTION
Due to the terraform provider's drift detection mechanism (e.g. [ActionsOrganizationSecret](https://github.com/integrations/terraform-provider-github/blob/2a17feb6f7e71925ff2b5f8eb13ee6f9680ee5bb/github/resource_github_actions_organization_secret.go#L202-L220)) and seemingly a mismatch between the `updated_at` values that Pulumi passes down and those that the provider gets from GitHub, secrets cannot get updated as they are always considered removed, so any property change requires a replacement and `selectedRepositoryIds` is no exception.