### PR TITLE
Set `selected_repository_ids` to ForceNew 

### DIFF
--- a/provider/cmd/pulumi-resource-github/schema.json
+++ b/provider/cmd/pulumi-resource-github/schema.json
@@ -3378,7 +3378,8 @@
                     "items": {
                         "type": "integer"
                     },
-                    "description": "An array of repository ids that can access the organization secret.\n"
+                    "description": "An array of repository ids that can access the organization secret.\n",
+                    "willReplaceOnChanges": true
                 },
                 "visibility": {
                     "type": "string",
@@ -3419,7 +3420,8 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "An array of repository ids that can access the organization secret.\n"
+                        "description": "An array of repository ids that can access the organization secret.\n",
+                        "willReplaceOnChanges": true
                     },
                     "updatedAt": {
                         "type": "string",
@@ -4812,7 +4814,8 @@
                     "items": {
                         "type": "integer"
                     },
-                    "description": "An array of repository ids that can access the organization secret.\n"
+                    "description": "An array of repository ids that can access the organization secret.\n",
+                    "willReplaceOnChanges": true
                 },
                 "visibility": {
                     "type": "string",
@@ -4853,7 +4856,8 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "An array of repository ids that can access the organization secret.\n"
+                        "description": "An array of repository ids that can access the organization secret.\n",
+                        "willReplaceOnChanges": true
                     },
                     "updatedAt": {
                         "type": "string",
@@ -5197,7 +5201,8 @@
                     "items": {
                         "type": "integer"
                     },
-                    "description": "An array of repository ids that can access the organization secret.\n"
+                    "description": "An array of repository ids that can access the organization secret.\n",
+                    "willReplaceOnChanges": true
                 },
                 "visibility": {
                     "type": "string",
@@ -5238,7 +5243,8 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "An array of repository ids that can access the organization secret.\n"
+                        "description": "An array of repository ids that can access the organization secret.\n",
+                        "willReplaceOnChanges": true
                     },
                     "updatedAt": {
                         "type": "string",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -102,6 +102,13 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"github_actions_environment_secret": {DeleteBeforeReplace: true},
+			"github_actions_organization_secret": {
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"selected_repository_ids": {
+						ForceNew: tfbridge.True(),
+					},
+				},
+			},
 
 			"github_actions_repository_permissions": {Tok: makeResource(mainMod, "ActionsRepositoryPermissions")},
 			"github_actions_runner_group":           {Tok: makeResource(mainMod, "ActionsRunnerGroup")},
@@ -123,9 +130,21 @@ func Provider() tfbridge.ProviderInfo {
 				TransformFromState: nil,
 			},
 			"github_branch_protection_v3": {Tok: makeResource(mainMod, "BranchProtectionV3")},
+			"github_codespaces_organization_secret": {
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"selected_repository_ids": {
+						ForceNew: tfbridge.True(),
+					},
+				},
+			},
 			"github_dependabot_organization_secret": {
 				Tok:  makeResource(mainMod, "DependabotOrganizationSecret"),
 				Docs: &tfbridge.DocInfo{AllowMissing: true},
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"selected_repository_ids": {
+						ForceNew: tfbridge.True(),
+					},
+				},
 			},
 			"github_dependabot_organization_secret_repositories": {
 				Tok:  makeResource(mainMod, "DependabotOrganizationSecretRepositories"),


### PR DESCRIPTION
Set Dependabot, Actions, and Codespaces Organization Secrets' selected_repository_ids fields to ForceNew.

Supersedes #709, where a user reported this bug and suggested a fix. This PR just incorporates the schema codegen.

