### PR TITLE
Enable zero default schema version for github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ sdk/java/gradlew.bat
 
 
 sdk/python/venv
+
+go.work
+go.work.sum

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -262,6 +262,7 @@ func Provider() tfbridge.ProviderInfo {
 				"Pulumi": "3.*",
 			},
 		},
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	prov.MustComputeTokens(tfbridgetokens.SingleModule("github_", mainMod,


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133

Enables zero default schema version for github.