### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -129,13 +129,7 @@ const repro586 = `[
             "diffs": "*",
             "detailedDiff": {
                 "restrictPushes": {
-                    "kind": "UPDATE"
-                },
-                "restrictPushes[0].blocksCreations": {},
-                "restrictPushes[0].pushAllowances": {
-                    "kind": "UPDATE"
-                },
-                "restrictPushes[0].pushAllowances[0]": {}
+                }
             },
             "hasDetailedDiff": true
         },

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -260,6 +260,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	prov.MustComputeTokens(tfbridgetokens.SingleModule("github_", mainMod,


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the pulumi-github provider. This should improve the quality of our previews for the provider.

It also updates the GRPC test to match the new behaviour.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2598