### PR TITLE
Enable RawStateDelta

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -261,6 +261,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		EnableZeroDefaultSchemaVersion: true,
 		EnableAccurateBridgePreview:    true,
+		EnableRawStateDelta:            true,
 	}
 
 	prov.MustComputeTokens(tfbridgetokens.SingleModule("github_", mainMod,


### PR DESCRIPTION
An experimental bridged feature for preserving Terraform raw state is being rolled out to this provider. See also:

- https://github.com/pulumi/pulumi-terraform-bridge/issues/1667
- https://github.com/pulumi/pulumi-terraform-bridge/issues/3003 
