### PR TITLE
Hoist selected_repository_ids field name into a constant for goconst

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -42,6 +42,10 @@ const (
 	mainMod = "index" // the y module
 )
 
+// selectedRepositoryIDs is the Terraform field name shared by several
+// organization secret resources.
+const selectedRepositoryIDs = "selected_repository_ids"
+
 // makeMember manufactures a type token for the package and the given module and type.
 func makeMember(mod string, mem string) tokens.ModuleMember {
 	return tokens.ModuleMember(mainPkg + ":" + mod + ":" + mem)
@@ -106,7 +110,7 @@ func Provider() tfbridge.ProviderInfo {
 			"github_actions_environment_secret": {DeleteBeforeReplace: true},
 			"github_actions_organization_secret": {
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"selected_repository_ids": {
+					selectedRepositoryIDs: {
 						ForceNew: tfbridge.True(),
 					},
 				},
@@ -134,7 +138,7 @@ func Provider() tfbridge.ProviderInfo {
 			"github_branch_protection_v3": {Tok: makeResource(mainMod, "BranchProtectionV3")},
 			"github_codespaces_organization_secret": {
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"selected_repository_ids": {
+					selectedRepositoryIDs: {
 						ForceNew: tfbridge.True(),
 					},
 				},
@@ -143,7 +147,7 @@ func Provider() tfbridge.ProviderInfo {
 				Tok:  makeResource(mainMod, "DependabotOrganizationSecret"),
 				Docs: &tfbridge.DocInfo{AllowMissing: true},
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"selected_repository_ids": {
+					selectedRepositoryIDs: {
 						ForceNew: tfbridge.True(),
 					},
 				},


### PR DESCRIPTION
The ci-mgmt workflow update bumps golangci-lint to 2.12.2, which enables stricter `goconst` checks. This hoists the repeated `selected_repository_ids` schema field name into a named constant. Verified locally with golangci-lint 2.12.2 (`make lint`) reporting 0 issues.

Part of #1226
Part of pulumi/home#4817
